### PR TITLE
chore: update README bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ irm https://d2learn.org/xlings-install.ps1.txt | iex
 ```bash
 xlings install d2x:mcpp-standard
 cd mcpp-standard
-d2x checker
+xlings d2x checker
 ```
 
 **👉 [more details...](https://sunrisepeak.github.io/mcpp-standard/base/chapter_1.html)**

--- a/README.zh.md
+++ b/README.zh.md
@@ -69,7 +69,7 @@ irm https://d2learn.org/xlings-install.ps1.txt | iex
 ```bash
 xlings install d2x:mcpp-standard
 cd mcpp-standard
-d2x checker
+xlings d2x checker
 ```
 
 **👉 [更多细节...](https://sunrisepeak.github.io/mcpp-standard/base/chapter_1.html)**


### PR DESCRIPTION
原 bash 中 `d2x checker` 无法执行，需要使用 `xlings d2x checker` 执行。