### PR TITLE
add some errors in final-and-override-1

### DIFF
--- a/dslings/cpp11/02-final-and-override-1.cpp
+++ b/dslings/cpp11/02-final-and-override-1.cpp
@@ -21,13 +21,13 @@
 #include <string>
 
 struct A {
-    virtual int func1() {
+    virtual int func1() final {
        return 1;
     }
     int func2() { return 2; }
 };
 
-struct B : A  {
+struct B final : A  {
 
     int func1() {
         return 3;


### PR DESCRIPTION
解决 #32 中的问题:
1. 将 `A::func1` 函数移除的 final 加回来
2. 看了下 final-and-override 这部分没有对类型加 final 的案例, 于是给 B 加了 final, 这样空的 `struct C` 也可以利用起来
3. 有个小建议, 可以配合 https://github.com/mcpp-community/mcpp-style-ref 项目增加一个 .clang-format 吗? 我使用的工具都设置了 format on save, 导致修改后整个文件的格式都发生了变化