### PR TITLE
fix(en/cpp11): sync xmake.lua with zh + add missing cpp11-15-variadic-templates

### DIFF
--- a/dslings/en/cpp11/15-variadic-templates-0.cpp
+++ b/dslings/en/cpp11/15-variadic-templates-0.cpp
@@ -1,0 +1,49 @@
+// d2mcpp: https://github.com/mcpp-community/d2mcpp
+// license: Apache-2.0
+// file: dslings/cpp11/15-variadic-templates-0.cpp
+//
+// Exercise: cpp11 | 15 - variadic templates | Variadic templates basics
+//
+// Tips:
+// - Variadic templates allow a function to accept any number of arguments
+// - In C++11, parameter packs are typically processed via recursion
+// - A recursion terminating function (base case) must be defined
+//
+// Docs:
+//   - https://en.cppreference.com/w/cpp/language/parameter_pack
+//   - https://github.com/mcpp-community/d2mcpp/blob/main/book/src/cpp11/15-variadic-templates.md
+//
+// Practice discussion: http://forum.d2learn.org/category/20
+//
+// Auto-Checker command:
+//
+//   d2x checker variadic-templates
+//
+
+#include <d2x/cpp/common.hpp>
+#include <sstream>
+
+std::stringstream ss;
+
+// Define the recursion terminating function
+// This is invoked when the parameter pack is empty
+D2X_YOUR_ANSWER
+
+// Define the variadic template function
+template<typename T,D2X_YOUR_ANSWER>
+void print(T first, D2X_YOUR_ANSWER args) {
+    ss << first << " ";
+    // Recursive call: process the remaining arguments
+    print(D2X_YOUR_ANSWER);
+}
+
+int main() {
+    print(1, "hello", 3.14);
+
+    std::string result = ss.str();
+    d2x_assert(result == "1 hello 3.14 ");
+
+    D2X_WAIT
+
+    return 0;
+}

--- a/dslings/en/cpp11/15-variadic-templates-1.cpp
+++ b/dslings/en/cpp11/15-variadic-templates-1.cpp
@@ -1,0 +1,40 @@
+// d2mcpp: https://github.com/mcpp-community/d2mcpp
+// license: Apache-2.0
+// file: dslings/cpp11/15-variadic-templates-1.cpp
+//
+// Exercise: cpp11 | 15 - variadic templates | Variadic template sum
+//
+// Tips:
+// - Implement the sum function using recursion
+// - Handle the recursion terminating condition as well
+//
+// Docs:
+//   - https://en.cppreference.com/w/cpp/language/parameter_pack
+//   - https://github.com/mcpp-community/d2mcpp/blob/main/book/src/cpp11/15-variadic-templates.md
+//
+
+#include <d2x/cpp/common.hpp>
+
+D2X_YOUR_ANSWER
+
+template<typename T, D2X_YOUR_ANSWER>
+T sum(T first, D2X_YOUR_ANSWER) {
+    return first + sum(D2X_YOUR_ANSWER);
+}
+
+int main() {
+    int res1 = sum(1, 2, 3, 4, 5);
+    d2x_assert_eq(res1, 15);
+
+    double res2 = sum(1.5, 2.5, 3.0);
+    d2x_assert(res2 == 7.0);
+
+    // Mixed types
+    // Note: the return type is determined by the first argument T
+    int res3 = sum(10, 20.5);
+    d2x_assert_eq(res3, 30);
+
+    D2X_WAIT
+
+    return 0;
+}

--- a/dslings/en/cpp11/xmake.lua
+++ b/dslings/en/cpp11/xmake.lua
@@ -55,8 +55,8 @@ target("cpp11-03-trailing-return-type")
 -- target: cpp11-04-rvalue-references
 
 target("cpp11-04-rvalue-references")
-set_optimize("none")
-add_cxxflags("-fno-elide-constructors")
+    set_optimize("none")
+    add_cxxflags("-fno-elide-constructors")
     add_files("04-rvalue-references.cpp")
 
 -- target: cpp11-05-move-semantics
@@ -81,7 +81,7 @@ target("cpp11-06-scoped-enums-1")
 -- target: cpp11-07-constexpr
 
 target("cpp11-07-constexpr-0")
-add_cxxflags("-Wpedantic -Werror")
+    add_cxxflags("-Wpedantic -Werror")
     add_files("07-constexpr-0.cpp")
 
 target("cpp11-07-constexpr-1")
@@ -90,6 +90,7 @@ target("cpp11-07-constexpr-1")
 -- target: cpp11-08-literal-type
 
 target("cpp11-08-literal-type-0")
+    set_languages("c++17") -- TODO: optimize it
     add_files("08-literal-type-0.cpp")
 
 target("cpp11-08-literal-type-1")
@@ -159,6 +160,14 @@ target("cpp11-14-type-alias-2")
 
 target("cpp11-14-type-alias-3")
     add_files("14-type-alias-3.cpp")
+
+-- target: cpp11-15-variadic-templates
+
+target("cpp11-15-variadic-templates-0")
+    add_files("15-variadic-templates-0.cpp")
+
+target("cpp11-15-variadic-templates-1")
+    add_files("15-variadic-templates-1.cpp")
 
 -- target: cpp11-16-generalized-unions
 


### PR DESCRIPTION
## Summary

- Fix #37 — the en version of `dslings/en/cpp11/xmake.lua` was missing `set_languages("c++17")` for the `cpp11-08-literal-type-0` target that the zh version already had. With C++11 default, the practice file errored on `non-constexpr operator[]` of `std::array`, obscuring the actual teaching errors about `constexpr std::string` not being a literal type.
- Also synced 3 other zh/en drift items found during the fix:
  - `cpp11-04-rvalue-references`: `set_optimize("none")` and `add_cxxflags("-fno-elide-constructors")` were unindented in en, leaking to file scope. Indented them to match zh.
  - `cpp11-07-constexpr-0`: `add_cxxflags("-Wpedantic -Werror")` had the same indentation issue. Fixed.
  - `cpp11-15-variadic-templates-0/1`: targets + source files were missing entirely from en. Added the xmake targets and English-translated source files.

After this PR, `dslings/cpp11/xmake.lua` and `dslings/en/cpp11/xmake.lua` are byte-identical.

## Test plan

- [x] `xmake f --lang=en && xmake build cpp11-08-literal-type-0` now produces the same 3 teaching errors as zh (`'const std::string' ... is not literal`, etc.) instead of the prior `non-constexpr operator[]` error.
- [x] `xmake build cpp11-04-rvalue-references` and `cpp11-07-constexpr-0` still build (and stop at their respective `D2X_YOUR_ANSWER` placeholder errors as expected).
- [x] `xmake build cpp11-15-variadic-templates-0` and `cpp11-15-variadic-templates-1` resolve to the new English source files (and stop at `D2X_YOUR_ANSWER` placeholder errors as expected).
- [x] `diff dslings/cpp11/xmake.lua dslings/en/cpp11/xmake.lua` returns nothing.

Closes #37