### PR TITLE
chore: fix en deploy trigger and zh ch01 SUMMARY placeholder

### DIFF
--- a/.github/workflows/online-ebook.yml
+++ b/.github/workflows/online-ebook.yml
@@ -10,6 +10,7 @@ on:
     branches: ["main"]
     paths:
       - "book/src/**"
+      - "book/en/src/**"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -10,7 +10,7 @@
 # C++11核心语言特性
 
 - [auto和decltype - 类型自动推导](./cpp11/00-auto-and-decltype.md)
-- [...](./cpp11/01-default-and-delete.md)
+- [default和delete - 默认/删除函数](./cpp11/01-default-and-delete.md)
 - [final 和 override - 虚函数重写控制](./cpp11/02-final-and-override.md)
 - [列表初始化](./cpp11/09-list-initialization.md)
 - [委托构造函数](./cpp11/10-delegating-constructors.md)


### PR DESCRIPTION
## Summary

review ch02 文档 PR 时顺手发现的两个小问题，合到一个清理 PR：

1. **\`online-ebook.yml\` 触发路径只覆盖 zh** — \`paths: [\"book/src/**\"]\` 漏了 \`book/en/src/**\`，所以纯 en 的 PR 不会触发部署。增加 en 路径条目，让 en-only 的章节翻译也能自动重新部署 GitHub Pages 站点。

2. **zh \`SUMMARY.md\` 里 ch01 是 \`[...]\` 占位** — 从 2025-07 sunrisepeak 当时章节做 stub 时留下的占位标签。换成正经标题 \`default和delete - 默认/删除函数\`，与 en 侧 \"Defaulted and Deleted Functions\" 对齐。注意：ch01 的 .md 内容本身依旧是 stub，需要后续单独写正文。

## Test plan

- [ ] 自动触发本 deploy workflow（这个 PR 改了 \`.github/workflows/\` 但触发路径不含此目录，所以本 PR 合入后不会自动部署 — 是预期行为）
- [ ] 下一次仅修改 \`book/en/src/**\` 的 PR 合入后，\`Deploy Online EBook site to Pages\` workflow 能触发并跑成功
- [ ] zh 在线版 ch01 sidebar 显示 \"default和delete - 默认/删除函数\" 而不是 \`...\`