### PR TITLE
docs(cpp11): fix missing exercise code links in 17-pod-type book chapter

### DIFF
--- a/book/en/src/cpp11/17-pod-type.md
+++ b/book/en/src/cpp11/17-pod-type.md
@@ -13,7 +13,7 @@ In C++, there is a corresponding category of **POD types** whose memory layout i
 
 | Book | Video | Code | Forum |
 | --- | --- | --- | --- |
-| [cppreference-PODType](https://cppreference.com/w/cpp/named_req/PODType.html) / [markdown](https://github.com/mcpp-community/d2mcpp/blob/main/book/src/cpp11/17-pod-type.md) | [Video Explanation]() | [Exercise Code]() | [Discussion Forum](https://forum.d2learn.org/category/20) |
+| [cppreference-PODType](https://cppreference.com/w/cpp/named_req/PODType.html) / [markdown](https://github.com/mcpp-community/d2mcpp/blob/main/book/src/cpp11/17-pod-type.md) | [Video Explanation]() | [Exercise Code](https://github.com/mcpp-community/d2mcpp/blob/main/dslings/cpp11/17-pod-type-0.cpp) | [Discussion Forum](https://forum.d2learn.org/category/20) |
 
 > Note: since C++20, the “PODType” notion in the standard has been marked **deprecated**.  
 > The standard library now prefers more fine-grained categories such as `TrivialType`, `StandardLayoutType`, and `ScalarType` to describe related requirements.
@@ -140,9 +140,9 @@ In new code, it is better to express constraints based on actual needs, for exam
 
 ### Exercise topics
 
-- 0 – Use type traits to check POD / trivial / standard-layout (`17-pod-type-0.cpp`)
-- 1 – Simulate byte-wise copying of a POD struct and observe the behavior (`17-pod-type-1.cpp`)
-- 2 – Adapt C++ message types to C interface using POD headers (`17-pod-type-2.cpp`)
+- 0 – [Use type traits to check POD / trivial / standard-layout](https://github.com/mcpp-community/d2mcpp/blob/main/dslings/en/cpp11/17-pod-type-0.cpp)
+- 1 – [Simulate byte-wise copying of a POD struct and observe the behavior](https://github.com/mcpp-community/d2mcpp/blob/main/dslings/en/cpp11/17-pod-type-1.cpp)
+- 2 – [Adapt C++ message types to C interface using POD headers](https://github.com/mcpp-community/d2mcpp/blob/main/dslings/en/cpp11/17-pod-type-2.cpp)
 
 ### Auto-check command
 

--- a/book/src/cpp11/17-pod-type.md
+++ b/book/src/cpp11/17-pod-type.md
@@ -13,7 +13,7 @@ C++ 早期标准为了描述这类“行为上接近 C struct 的类型”，引
 
 | 书籍 | 视频 | 代码 | 交流 |
 | --- | --- | --- | --- |
-| [cppreference-PODType](https://cppreference.com/w/cpp/named_req/PODType.html) / [markdown](https://github.com/mcpp-community/d2mcpp/blob/main/book/src/cpp11/17-pod-type.md) | [视频解读]() | [练习代码]() | [论坛讨论](https://forum.d2learn.org/category/20) |
+| [cppreference-PODType](https://cppreference.com/w/cpp/named_req/PODType.html) / [markdown](https://github.com/mcpp-community/d2mcpp/blob/main/book/src/cpp11/17-pod-type.md) | [视频解读]() | [练习代码](https://github.com/mcpp-community/d2mcpp/blob/main/dslings/cpp11/17-pod-type-0.cpp) | [论坛讨论](https://forum.d2learn.org/category/20) |
 
 > 注意：从 C++20 开始，标准中的 “PODType” 概念已被标记为**弃用**。标准库更倾向于使用更细化的类别，如 `TrivialType`、`StandardLayoutType`、`ScalarType` 等来描述相关需求。
 
@@ -140,9 +140,9 @@ void pod_only_copy(const T& src, T& dst) {
 
 ### 练习代码主题
 
-- 0 - 使用类型特征判断 POD / trivial / standard layout（`17-pod-type-0.cpp`）
-- 1 - 模拟按字节拷贝 POD 结构体，体会其行为（`17-pod-type-1.cpp`）
-- 2 - 为 C 接口传入合适的 POD 类型数据（`17-pod-type-2.cpp`）
+- 0 - [使用类型特征判断 POD / trivial / standard layout](https://github.com/mcpp-community/d2mcpp/blob/main/dslings/cpp11/17-pod-type-0.cpp)
+- 1 - [模拟按字节拷贝 POD 结构体，体会其行为](https://github.com/mcpp-community/d2mcpp/blob/main/dslings/cpp11/17-pod-type-1.cpp)
+- 2 - [为 C 接口传入合适的 POD 类型数据](https://github.com/mcpp-community/d2mcpp/blob/main/dslings/cpp11/17-pod-type-2.cpp)
 
 ### 练习代码自动检测命令
 


### PR DESCRIPTION
docs(cpp11): fix missing exercise code links in 17-pod-type book chapter

Fill in empty exercise code links in both zh and en book chapters:

- fix empty Code link in header table
- add GitHub links to exercise topic list

Closes #58

CLA: I have read the CLA and by submitting this PR agree to its terms.