### PR TITLE
docs: document xmake and Mingw-w64 dependency for Windows setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,17 @@ cd d2mcpp
 d2x checker
 ```
 
+> On Windows, `d2x checker` requires [xmake](https://xmake.io/#/getting_started) and a GCC toolchain (Mingw-w64). Install both first:
+>
+> ```
+> winget install xmake          # or: scoop install xmake
+> winget install MSYS2.MSYS2    # then in MSYS2: pacman -S mingw-w64-x86_64-gcc
+> ```
+>
+> Then configure xmake to use the GCC toolchain: `xmake f --toolchain=mingw`
+
+**👉 [more details...]
+
 **👉 [more details...](https://mcpp-community.github.io/d2mcpp/base/chapter_1.html)**
 
 ## Community

--- a/README.zh.md
+++ b/README.zh.md
@@ -73,6 +73,17 @@ cd d2mcpp
 d2x checker
 ```
 
+> Windows 上 `d2x checker` 依赖 [xmake](https://xmake.io/#/getting_started) 和 GCC 工具链 (Mingw-w64)，需先安装两者:
+>
+> ```
+> winget install xmake          # 或: scoop install xmake
+> winget install MSYS2.MSYS2    # 然后在 MSYS2 中: pacman -S mingw-w64-x86_64-gcc
+> ```
+>
+> 然后配置 xmake 使用 GCC 工具链: `xmake f --toolchain=mingw`
+
+**👉 [更多细节...]
+
 **👉 [更多细节...](https://mcpp-community.github.io/d2mcpp/base/chapter_1.html)**
 
 ## 社区

--- a/book/src/base/chapter_1.md
+++ b/book/src/base/chapter_1.md
@@ -38,7 +38,17 @@ Invoke-Expression (Invoke-Webrequest 'https://raw.githubusercontent.com/openxlin
 
 ```bash
 d2x install d2mcpp
+cd d2mcpp
 ```
+
+> Windows 上需额外安装 [xmake](https://xmake.io/#/getting_started) 和 Mingw-w64 工具链:
+>
+> ```
+> winget install xmake          # 或: scoop install xmake
+> winget install MSYS2.MSYS2    # 然后在 MSYS2 中: pacman -S mingw-w64-x86_64-gcc
+> ```
+>
+> 然后配置 xmake 使用 GCC 工具链: `xmake f --toolchain=mingw`
 
 ### 本地电子书
 


### PR DESCRIPTION
docs: document xmake and Mingw-w64 dependency for Windows setup

Add install commands for xmake and Mingw-w64 toolchain to the README
and usage guide. The existing setup flow (xlings install d2x → d2x
install d2mcpp) does not pull these in on Windows, causing d2x checker
to fail with "'xmake' is not recognized" or "toolchain(gcc): not found".

Closes #72 

CLA: I have read the CLA and by submitting this PR agree to its terms.
