### PR TITLE
feat(cpp14): add 04-decltype-auto book chapter, exercises, solutions, and build wiring

### DIFF
--- a/book/en/src/SUMMARY.md
+++ b/book/en/src/SUMMARY.md
@@ -31,6 +31,7 @@
 # C++14 Core Language Features
 
 - [Generic Lambdas](./cpp14/00-generic-lambdas.md)
+- [decltype(auto)](./cpp14/04-decltype-auto.md)
 
 # Additional Resources
 

--- a/book/en/src/cpp14/04-decltype-auto.md
+++ b/book/en/src/cpp14/04-decltype-auto.md
@@ -1,0 +1,118 @@
+<div align=right>
+
+  🌎 [中文] | [English]
+</div>
+
+[中文]: ../../cpp14/04-decltype-auto.html
+[English]: ./04-decltype-auto.html
+
+# decltype(auto)
+
+C++14 introduces `decltype(auto)` as a return type, deducing using decltype rules to precisely preserve reference and cv-qualification
+
+| Book | Video | Code | X |
+| --- | --- | --- | --- |
+| [cppreference-auto](https://en.cppreference.com/w/cpp/language/auto) / [markdown](https://github.com/mcpp-community/d2mcpp/blob/main/book/en/src/cpp14/04-decltype-auto.md) | [Video Explanation]() | [Exercise Code](https://github.com/mcpp-community/d2mcpp/blob/main/dslings/en/cpp14/04-decltype-auto-0.cpp) |  |
+
+
+**Why introduced?**
+
+- `auto` return strips references and top-level const, causing unexpected copies in forwarding and getters
+- `decltype(auto)` deduces using decltype rules, precisely preserving the value category and type qualifiers
+
+**auto return vs decltype(auto)**
+
+```cpp
+int x = 42;
+
+auto         f1() { return (x); }  // returns int
+decltype(auto) f2() { return (x); }  // returns int&, preserves reference
+```
+
+## I. Basic Usage and Scenarios
+
+### Preserving Reference Returns
+
+```cpp
+int global = 100;
+
+decltype(auto) get_ref() {
+    return (global);  // returns int&, modifiable externally
+}
+
+get_ref() = 200;  // modifies global
+```
+
+### Forwarding Pattern
+
+```cpp
+template <typename T>
+decltype(auto) forwarder(T&& arg) {
+    return std::forward<T>(arg);
+}
+```
+
+### Container Element Access
+
+```cpp
+std::vector<int> v = {1, 2, 3};
+
+decltype(auto) get_at(std::vector<int>& vec, size_t i) {
+    return vec[i];  // returns int&
+}
+```
+
+## II. Real-World Case — decltype(auto) Forwarding in the STL
+
+> The MSVC STL uses `decltype(auto)` for forwarding call results while precisely preserving the return value category. The example below cites the vendored [MSVC STL](https://github.com/mcpp-community/d2mcpp/tree/main/msvc-stl) (source: [`msvc-stl/stl/inc/xutility`](https://github.com/mcpp-community/d2mcpp/blob/main/msvc-stl/stl/inc/xutility#L943-L947))
+
+```cpp
+// MSVC STL · msvc-stl/stl/inc/xutility (abridged)
+template <class... _Args>
+constexpr decltype(auto) operator()(_Args&&... _Vals) noexcept(...) {
+    return _STD invoke(_Fn, _STD forward<_Args>(_Vals)...);
+}
+```
+
+`std::invoke` may return an lvalue reference (e.g. `std::get<T&>(tuple)`) or an rvalue (e.g. move semantics). `decltype(auto)` ensures the original value category reaches the caller — no accidental copies from auto stripping, no loss of const qualification
+
+## III. Notes
+
+### Parentheses Trap
+
+`decltype(auto)` treats `return x;` and `return (x);` differently:
+
+```cpp
+int x = 10;
+decltype(auto) f1() { return  x; }  // int
+decltype(auto) f2() { return (x); } // int& — watch out!
+```
+
+### decltype(auto) in Variable Declarations
+
+```cpp
+int x = 42;
+decltype(auto) y = x;   // int
+decltype(auto) z = (x);  // int& — same parentheses rule applies
+```
+
+
+## IV. Exercise Code
+
+### Exercise Topics
+
+- 0 - [decltype(auto) — Reference Preservation and Forwarding](https://github.com/mcpp-community/d2mcpp/blob/main/dslings/en/cpp14/04-decltype-auto-0.cpp)
+- 1 - [decltype(auto) — Parentheses Trap and Variable Declarations](https://github.com/mcpp-community/d2mcpp/blob/main/dslings/en/cpp14/04-decltype-auto-1.cpp)
+
+### Auto-Checker Command
+
+```
+d2x checker decltype-auto
+```
+
+## V. Other
+
+- [Discussion Forum](https://forum.d2learn.org/category/20)
+- [d2mcpp Tutorial Repository](https://github.com/mcpp-community/d2mcpp)
+- [Tutorial Video List](https://space.bilibili.com/65858958/lists/5208246)
+- [Tutorial Support Tool - xlings](https://github.com/openxlings/xlings)

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -31,6 +31,7 @@
 # C++14核心语言特性
 
 - [泛型 lambda - generic lambdas](./cpp14/00-generic-lambdas.md)
+- [decltype(auto)](./cpp14/04-decltype-auto.md)
 
 # 其他
 

--- a/book/src/cpp14/04-decltype-auto.md
+++ b/book/src/cpp14/04-decltype-auto.md
@@ -1,0 +1,121 @@
+<div align=right>
+
+  🌎 [中文] | [English]
+</div>
+
+[中文]: ./04-decltype-auto.html
+[English]: ../en/cpp14/04-decltype-auto.html
+
+# decltype(auto)
+
+C++14 引入 `decltype(auto)` 返回类型, 按 decltype 规则精确保留表达式类型, 解决 auto 返回剥离引用和 cv 限定的问题
+
+| Book | Video | Code | X |
+| --- | --- | --- | --- |
+| [cppreference-auto](https://en.cppreference.com/w/cpp/language/auto) / [markdown](https://github.com/mcpp-community/d2mcpp/blob/main/book/src/cpp14/04-decltype-auto.md) | [视频解读]() | [练习代码](https://github.com/mcpp-community/d2mcpp/blob/main/dslings/cpp14/04-decltype-auto-0.cpp) |  |
+
+
+**为什么引入?**
+
+- `auto` 返回会剥离引用和顶层 const, 在转发函数和 getter 中导致意外拷贝
+- `decltype(auto)` 使用 decltype 规则推导, 精确保留返回表达式的值类别和类型修饰
+
+**auto 返回 vs decltype(auto)**
+
+```cpp
+int x = 42;
+
+auto         f1() { return (x); }  // 返回 int
+decltype(auto) f2() { return (x); }  // 返回 int&, 保留引用
+```
+
+## 一、基础用法和场景
+
+### 保留引用返回
+
+```cpp
+int global = 100;
+
+decltype(auto) get_ref() {
+    return (global);  // 返回 int&, 外部可修改
+}
+
+get_ref() = 200;  // 修改 global
+```
+
+### 转发模式
+
+```cpp
+template <typename T>
+decltype(auto) forwarder(T&& arg) {
+    return std::forward<T>(arg);  // 精确保留值类别
+}
+```
+
+### 容器元素访问
+
+```cpp
+std::vector<int> v = {1, 2, 3};
+
+decltype(auto) get_at(std::vector<int>& vec, size_t i) {
+    return vec[i];  // 返回 int&, 允许外部修改
+}
+
+get_at(v, 0) = 10;  // v[0] 现在为 10
+```
+
+## 二、真实案例 - STL 中的 decltype(auto) 转发
+
+> MSVC STL 使用 `decltype(auto)` 在转发调用时精确保留返回值类型。下面以仓库内置的 [MSVC STL](https://github.com/mcpp-community/d2mcpp/tree/main/msvc-stl) 为例 (源码: [`msvc-stl/stl/inc/xutility`](https://github.com/mcpp-community/d2mcpp/blob/main/msvc-stl/stl/inc/xutility#L943-L947))
+
+```cpp
+// MSVC STL · msvc-stl/stl/inc/xutility (有删节)
+template <class... _Args>
+constexpr decltype(auto) operator()(_Args&&... _Vals) noexcept(...) {
+    return _STD invoke(_Fn, _STD forward<_Args>(_Vals)...);
+}
+```
+
+`std::invoke` 可能返回左值引用 (如 `std::get<T&>(tuple)`), 也可能返回右值 (如移动语义)。`decltype(auto)` 让返回值以原值类别呈现给调用方 — 不会因 auto 剥离而意外拷贝, 也不会丢失 const 限定
+
+## 三、注意事项
+
+### 括号陷阱
+
+`decltype(auto)` 对 `return x;` 和 `return (x);` 的推导不同:
+
+```cpp
+int x = 10;
+decltype(auto) f1() { return  x; }  // int
+decltype(auto) f2() { return (x); } // int& — 注意!
+```
+
+### decltype(auto) 也可用于变量声明
+
+```cpp
+int x = 42;
+decltype(auto) y = x;   // int
+decltype(auto) z = (x);  // int& — 同样受括号影响
+```
+
+`decltype(auto)` 在变量声明和返回类型推导中都可用, 遵循同样的 decltype 推导规则
+
+## 四、练习代码
+
+### 练习代码主题
+
+- 0 - [decltype(auto) — 引用保留与转发](https://github.com/mcpp-community/d2mcpp/blob/main/dslings/cpp14/04-decltype-auto-0.cpp)
+- 1 - [decltype(auto) — 括号陷阱与变量声明](https://github.com/mcpp-community/d2mcpp/blob/main/dslings/cpp14/04-decltype-auto-1.cpp)
+
+### 练习代码自动检测命令
+
+```
+d2x checker decltype-auto
+```
+
+## 五、其他
+
+- [交流讨论](https://forum.d2learn.org/category/20)
+- [d2mcpp教程仓库](https://github.com/mcpp-community/d2mcpp)
+- [教程视频列表](https://space.bilibili.com/65858958/lists/5208246)
+- [教程支持工具-xlings](https://github.com/openxlings/xlings)

--- a/dslings/cpp14/04-decltype-auto-0.cpp
+++ b/dslings/cpp14/04-decltype-auto-0.cpp
@@ -1,0 +1,60 @@
+// d2mcpp: https://github.com/mcpp-community/d2mcpp
+// license: Apache-2.0
+// file: dslings/cpp14/04-decltype-auto-0.cpp
+//
+// Exercise/练习: cpp14 | 04 - decltype(auto) | 引用保留与转发
+//
+// Tips/提示:
+// - decltype(auto) 按 decltype 规则推导, 精确保留引用和 cv 限定
+// - auto 返回会剥离引用, decltype(auto) 不会
+//
+// Docs/文档:
+//   - https://en.cppreference.com/w/cpp/language/auto
+//   - https://github.com/mcpp-community/d2mcpp/blob/main/book/src/cpp14/04-decltype-auto.md
+//
+// 练习交流讨论: http://forum.d2learn.org/category/20
+//
+// Auto-Checker/自动检测命令:
+//
+//   d2x checker decltype-auto
+//
+
+#include <d2x/cpp/common.hpp>
+
+int g_val = 100;
+
+auto get_ref_auto() {
+    return (g_val);
+}
+
+D2X_YOUR_ANSWER get_ref_declauto() {
+    return (D2X_YOUR_ANSWER);
+}
+
+template <typename T>
+D2X_YOUR_ANSWER forward_value(T&& arg) {
+    return std::forward<T>(D2X_YOUR_ANSWER);
+}
+
+int main() {
+
+    auto a1 = get_ref_auto();
+    d2x_assert_eq(a1, 100);
+    ++a1;
+    d2x_assert_eq(g_val, 100);
+
+    auto& a2 = get_ref_declauto();
+    d2x_assert_eq(a2, 100);
+    ++a2;
+    d2x_assert_eq(g_val, D2X_YOUR_ANSWER);
+
+    int x = 10;
+    auto& f1 = forward_value<int&>(x);
+    d2x_assert_eq(f1, 10);
+    ++f1;
+    d2x_assert_eq(x, 11);
+
+    D2X_WAIT
+
+    return 0;
+}

--- a/dslings/cpp14/04-decltype-auto-1.cpp
+++ b/dslings/cpp14/04-decltype-auto-1.cpp
@@ -1,0 +1,62 @@
+// d2mcpp: https://github.com/mcpp-community/d2mcpp
+// license: Apache-2.0
+// file: dslings/cpp14/04-decltype-auto-1.cpp
+//
+// Exercise/练习: cpp14 | 04 - decltype(auto) | 括号陷阱与变量声明
+//
+// Tips/提示:
+// - decltype(auto) 在变量声明中遵循 decltype 推导规则
+// - return x 和 return (x) 在 decltype(auto) 下推导结果不同
+//
+// Docs/文档:
+//   - https://en.cppreference.com/w/cpp/language/auto
+//   - https://github.com/mcpp-community/d2mcpp/blob/main/book/src/cpp14/04-decltype-auto.md
+//
+// 练习交流讨论: http://forum.d2learn.org/category/20
+//
+// Auto-Checker/自动检测命令:
+//
+//   d2x checker decltype-auto
+//
+
+#include <d2x/cpp/common.hpp>
+
+int val = 50;
+
+// 返回名 → 值类型
+decltype(auto) return_name() {
+    return D2X_YOUR_ANSWER;
+}
+
+// 返回 (名) → 引用类型
+decltype(auto) return_paren() {
+    return (D2X_YOUR_ANSWER);
+}
+
+int main() {
+
+    // 0. 变量声明中使用 decltype(auto)
+    D2X_YOUR_ANSWER v1 = val;
+    v1 = 99;
+    d2x_assert_eq(val, 50);
+
+    decltype(auto) v2 = (D2X_YOUR_ANSWER);
+    v2 = 99;
+    d2x_assert_eq(val, 99);
+
+    // 1. return_name 返回的是值, 修改不影响原变量
+    auto a1 = return_name();
+    d2x_assert_eq(a1, 50);
+    ++a1;
+    d2x_assert_eq(val, 99);
+
+    // 2. return_paren 返回的是引用, 修改直接影响原变量
+    auto& a2 = return_paren();
+    d2x_assert_eq(a2, D2X_YOUR_ANSWER);
+    ++a2;
+    d2x_assert_eq(val, 100);
+
+    D2X_WAIT
+
+    return 0;
+}

--- a/dslings/cpp14/xmake.lua
+++ b/dslings/cpp14/xmake.lua
@@ -9,3 +9,13 @@ target("cpp14-00-generic-lambdas-0")
 target("cpp14-00-generic-lambdas-1")
     set_kind("binary")
     add_files("00-generic-lambdas-1.cpp")
+
+-- target: cpp14-04-decltype-auto
+
+target("cpp14-04-decltype-auto-0")
+    set_kind("binary")
+    add_files("04-decltype-auto-0.cpp")
+
+target("cpp14-04-decltype-auto-1")
+    set_kind("binary")
+    add_files("04-decltype-auto-1.cpp")

--- a/dslings/en/cpp14/04-decltype-auto-0.cpp
+++ b/dslings/en/cpp14/04-decltype-auto-0.cpp
@@ -1,0 +1,61 @@
+// d2mcpp: https://github.com/mcpp-community/d2mcpp
+// license: Apache-2.0
+// file: dslings/en/cpp14/04-decltype-auto-0.cpp
+//
+// Exercise: cpp14 | 04 - decltype(auto) | reference preservation and forwarding
+//
+// Tips:
+// - decltype(auto) deduces using decltype rules, precisely preserving
+//   references and cv-qualifiers
+// - auto return strips references; decltype(auto) does not
+//
+// Docs:
+//   - https://en.cppreference.com/w/cpp/language/auto
+//   - https://github.com/mcpp-community/d2mcpp/blob/main/book/en/src/cpp14/04-decltype-auto.md
+//
+// Discussion Forum: http://forum.d2learn.org/category/20
+//
+// Auto-Checker:
+//
+//   d2x checker decltype-auto
+//
+
+#include <d2x/cpp/common.hpp>
+
+int g_val = 100;
+
+auto get_ref_auto() {
+    return (g_val);
+}
+
+D2X_YOUR_ANSWER get_ref_declauto() {
+    return (D2X_YOUR_ANSWER);
+}
+
+template <typename T>
+D2X_YOUR_ANSWER forward_value(T&& arg) {
+    return std::forward<T>(D2X_YOUR_ANSWER);
+}
+
+int main() {
+
+    auto a1 = get_ref_auto();
+    d2x_assert_eq(a1, 100);
+    ++a1;
+    d2x_assert_eq(g_val, 100);
+
+    auto& a2 = get_ref_declauto();
+    d2x_assert_eq(a2, 100);
+    ++a2;
+    d2x_assert_eq(g_val, D2X_YOUR_ANSWER);
+
+    int x = 10;
+    auto& f1 = forward_value<int&>(x);
+    d2x_assert_eq(f1, 10);
+    ++f1;
+    d2x_assert_eq(x, 11);
+
+    D2X_WAIT
+
+    return 0;
+}

--- a/dslings/en/cpp14/04-decltype-auto-1.cpp
+++ b/dslings/en/cpp14/04-decltype-auto-1.cpp
@@ -1,0 +1,62 @@
+// d2mcpp: https://github.com/mcpp-community/d2mcpp
+// license: Apache-2.0
+// file: dslings/en/cpp14/04-decltype-auto-1.cpp
+//
+// Exercise: cpp14 | 04 - decltype(auto) | parentheses trap and variable declarations
+//
+// Tips:
+// - decltype(auto) in variable declarations follows decltype deduction rules
+// - return x and return (x) deduce differently under decltype(auto)
+//
+// Docs:
+//   - https://en.cppreference.com/w/cpp/language/auto
+//   - https://github.com/mcpp-community/d2mcpp/blob/main/book/en/src/cpp14/04-decltype-auto.md
+//
+// Discussion Forum: http://forum.d2learn.org/category/20
+//
+// Auto-Checker:
+//
+//   d2x checker decltype-auto
+//
+
+#include <d2x/cpp/common.hpp>
+
+int val = 50;
+
+// return name → value type
+decltype(auto) return_name() {
+    return D2X_YOUR_ANSWER;
+}
+
+// return (name) → reference type
+decltype(auto) return_paren() {
+    return (D2X_YOUR_ANSWER);
+}
+
+int main() {
+
+    // 0. decltype(auto) in variable declarations
+    D2X_YOUR_ANSWER v1 = val;
+    v1 = 99;
+    d2x_assert_eq(val, 50);
+
+    decltype(auto) v2 = (D2X_YOUR_ANSWER);
+    v2 = 99;
+    d2x_assert_eq(val, 99);
+
+    // 1. return_name returns by value, modifications don't affect original
+    auto a1 = return_name();
+    d2x_assert_eq(a1, 50);
+    ++a1;
+    d2x_assert_eq(val, 99);
+
+    // 2. return_paren returns by reference, modifications affect original
+    auto& a2 = return_paren();
+    d2x_assert_eq(a2, D2X_YOUR_ANSWER);
+    ++a2;
+    d2x_assert_eq(val, 100);
+
+    D2X_WAIT
+
+    return 0;
+}

--- a/dslings/en/cpp14/xmake.lua
+++ b/dslings/en/cpp14/xmake.lua
@@ -9,3 +9,13 @@ target("cpp14-00-generic-lambdas-0")
 target("cpp14-00-generic-lambdas-1")
     set_kind("binary")
     add_files("00-generic-lambdas-1.cpp")
+
+-- target: cpp14-04-decltype-auto
+
+target("cpp14-04-decltype-auto-0")
+    set_kind("binary")
+    add_files("04-decltype-auto-0.cpp")
+
+target("cpp14-04-decltype-auto-1")
+    set_kind("binary")
+    add_files("04-decltype-auto-1.cpp")

--- a/solutions/cpp14/04-decltype-auto-0.cpp
+++ b/solutions/cpp14/04-decltype-auto-0.cpp
@@ -1,0 +1,45 @@
+// d2mcpp: https://github.com/mcpp-community/d2mcpp
+// license: Apache-2.0
+// reference solution for: dslings/cpp14/04-decltype-auto-0.cpp
+//
+// 用途: 仅给 CI 与维护者参考使用，不是教程入口。
+// 教程练习入口: dslings/cpp14/04-decltype-auto-0.cpp
+//
+
+#include <d2x/cpp/common.hpp>
+
+int g_val = 100;
+
+auto get_ref_auto() {
+    return (g_val);
+}
+
+decltype(auto) get_ref_declauto() {
+    return (g_val);
+}
+
+template <typename T>
+decltype(auto) forward_value(T&& arg) {
+    return std::forward<T>(arg);
+}
+
+int main() {
+
+    auto a1 = get_ref_auto();
+    d2x_assert_eq(a1, 100);
+    ++a1;
+    d2x_assert_eq(g_val, 100);
+
+    auto& a2 = get_ref_declauto();
+    d2x_assert_eq(a2, 100);
+    ++a2;
+    d2x_assert_eq(g_val, 101);
+
+    int x = 10;
+    auto& f1 = forward_value<int&>(x);
+    d2x_assert_eq(f1, 10);
+    ++f1;
+    d2x_assert_eq(x, 11);
+
+    return 0;
+}

--- a/solutions/cpp14/04-decltype-auto-1.cpp
+++ b/solutions/cpp14/04-decltype-auto-1.cpp
@@ -1,0 +1,42 @@
+// d2mcpp: https://github.com/mcpp-community/d2mcpp
+// license: Apache-2.0
+// reference solution for: dslings/cpp14/04-decltype-auto-1.cpp
+//
+// 用途: 仅给 CI 与维护者参考使用，不是教程入口。
+// 教程练习入口: dslings/cpp14/04-decltype-auto-1.cpp
+//
+
+#include <d2x/cpp/common.hpp>
+
+int val = 50;
+
+decltype(auto) return_name() {
+    return val;
+}
+
+decltype(auto) return_paren() {
+    return (val);
+}
+
+int main() {
+
+    decltype(auto) v1 = val;
+    v1 = 99;
+    d2x_assert_eq(val, 50);
+
+    decltype(auto) v2 = (val);
+    v2 = 99;
+    d2x_assert_eq(val, 99);
+
+    auto a1 = return_name();
+    d2x_assert_eq(a1, 99);
+    ++a1;
+    d2x_assert_eq(val, 99);
+
+    auto& a2 = return_paren();
+    d2x_assert_eq(a2, 99);
+    ++a2;
+    d2x_assert_eq(val, 100);
+
+    return 0;
+}

--- a/solutions/cpp14/xmake.lua
+++ b/solutions/cpp14/xmake.lua
@@ -9,3 +9,13 @@ target("cpp14-00-generic-lambdas-0-ref")
 target("cpp14-00-generic-lambdas-1-ref")
     set_kind("binary")
     add_files("00-generic-lambdas-1.cpp")
+
+-- target: cpp14-04-decltype-auto
+
+target("cpp14-04-decltype-auto-0-ref")
+    set_kind("binary")
+    add_files("04-decltype-auto-0.cpp")
+
+target("cpp14-04-decltype-auto-1-ref")
+    set_kind("binary")
+    add_files("04-decltype-auto-1.cpp")


### PR DESCRIPTION
feat(cpp14): add 04-decltype-auto book chapter, exercises, solutions, and build wiring

Add the fifth C++14 chapter covering decltype(auto).

Book chapter (zh + en):
  - section 一/I: Basic usage — reference preservation, forwarding
    pattern, container element access
  - section 二/II: Real-world case — _Pass_fn operator() from vendored
    msvc-stl/stl/inc/xutility#L943-L947, decltype(auto) forwarding
    std::invoke return preserves value category
  - section 三/III: Notes — parentheses trap (return x vs return (x)),
    variable declaration usage
  - section 四/IV: Exercise topics and d2x checker command
  - section 五/V: External resources

Exercise progression:
  0. decltype(auto) reference preservation and forwarding — auto vs
     decltype(auto) contrast, global reference, forwarding template.
     5 D2X_YOUR_ANSWER.
  1. Parentheses trap and variable declarations — return x vs return (x),
     decltype(auto) in variable declarations. 6 D2X_YOUR_ANSWER.

Build wiring:
  - register 04 targets in dslings/cpp14, dslings/en/cpp14,
    solutions/cpp14
  - add 04 entry to zh/en SUMMARY.md

Closes #66

CLA: I have read the CLA and by submitting this PR agree to its terms.
