### PR TITLE
feat(cpp14): add 05-binary-literals book chapter, exercise, solution, and build wiring

### DIFF
--- a/book/en/src/SUMMARY.md
+++ b/book/en/src/SUMMARY.md
@@ -32,6 +32,8 @@
 
 - [Generic Lambdas](./cpp14/00-generic-lambdas.md)
 
+- [Binary Literals](./cpp14/05-binary-literals.md)
+
 # Additional Resources
 
 - [Changelog](changelog.md)

--- a/book/en/src/cpp14/05-binary-literals.md
+++ b/book/en/src/cpp14/05-binary-literals.md
@@ -1,0 +1,78 @@
+<div align=right>
+
+  🌎 [中文] | [English]
+</div>
+
+[中文]: ../../cpp14/05-binary-literals.html
+[English]: ./05-binary-literals.html
+
+# Binary Literals
+
+C++14 introduces the `0b` / `0B` prefix for binary integer literals, making bit-level values directly readable
+
+| Book | Video | Code | X |
+| --- | --- | --- | --- |
+| [cppreference-integer_literal](https://en.cppreference.com/w/cpp/language/integer_literal) / [markdown](https://github.com/mcpp-community/d2mcpp/blob/main/book/en/src/cpp14/05-binary-literals.md) | [Video Explanation]() | [Exercise Code](https://github.com/mcpp-community/d2mcpp/blob/main/dslings/en/cpp14/05-binary-literals-0.cpp) |  |
+
+
+**Why introduced?**
+
+Bit masks and flag bits expressed in decimal or hex cannot directly convey the binary bit layout. `0b0010'1100` makes every bit's meaning visible at a glance
+
+## I. Basic Usage and Scenarios
+
+```cpp
+int a = 0b1010;       // 10
+int b = 0B1111;       // 15
+
+// Bit masks — binary representation is the most intuitive
+constexpr unsigned READ  = 0b001;
+constexpr unsigned WRITE = 0b010;
+constexpr unsigned EXEC  = 0b100;
+
+unsigned perm = 0b101;  // READ | EXEC
+```
+
+## II. Real-World Case — Binary Literals in the STL
+
+> The MSVC STL uses binary literals for bit masks in Unicode handling. The example below cites the vendored [MSVC STL](https://github.com/mcpp-community/d2mcpp/tree/main/msvc-stl) (source: [`msvc-stl/stl/inc/format`](https://github.com/mcpp-community/d2mcpp/blob/main/msvc-stl/stl/inc/format#L259-L267))
+
+```cpp
+// MSVC STL · msvc-stl/stl/inc/format (abridged)
+// UTF-8 encoding — mask out the effective bits per byte count
+switch (_Num_bytes) {
+case 2:
+    _Val &= 0b1'1111u;   // 2 bytes: keep lower 5 bits
+    break;
+case 3:
+    _Val &= 0b1111u;     // 3 bytes: keep lower 4 bits
+    break;
+case 4:
+    _Val &= 0b111u;      // 4 bytes: keep lower 3 bits
+}
+```
+
+## III. Notes
+
+- Binary literals can only be used with integer types
+- Can be combined with digit separators: `0b1010'1100`
+- Both `0b` and `0B` work; `0b` is more common
+
+## IV. Exercise Code
+
+### Exercise Topics
+
+- 0 - [Binary Literals — Bit Mask Operations](https://github.com/mcpp-community/d2mcpp/blob/main/dslings/en/cpp14/05-binary-literals-0.cpp)
+
+### Auto-Checker Command
+
+```
+d2x checker binary-literals
+```
+
+## V. Other
+
+- [Discussion Forum](https://forum.d2learn.org/category/20)
+- [d2mcpp Tutorial Repository](https://github.com/mcpp-community/d2mcpp)
+- [Tutorial Video List](https://space.bilibili.com/65858958/lists/5208246)
+- [Tutorial Support Tool - xlings](https://github.com/openxlings/xlings)

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -32,6 +32,8 @@
 
 - [泛型 lambda - generic lambdas](./cpp14/00-generic-lambdas.md)
 
+- [二进制字面量 - binary literals](./cpp14/05-binary-literals.md)
+
 # 其他
 
 - [更新日志](changelog.md)

--- a/book/src/cpp14/05-binary-literals.md
+++ b/book/src/cpp14/05-binary-literals.md
@@ -1,0 +1,80 @@
+<div align=right>
+
+  🌎 [中文] | [English]
+</div>
+
+[中文]: ./05-binary-literals.html
+[English]: ../en/cpp14/05-binary-literals.html
+
+# 二进制字面量 - binary literals
+
+C++14 引入 `0b` / `0B` 前缀表示二进制字面量, 让位运算和底层编程中的数值表示更加直观
+
+| Book | Video | Code | X |
+| --- | --- | --- | --- |
+| [cppreference-integer_literal](https://en.cppreference.com/w/cpp/language/integer_literal) / [markdown](https://github.com/mcpp-community/d2mcpp/blob/main/book/src/cpp14/05-binary-literals.md) | [视频解读]() | [练习代码](https://github.com/mcpp-community/d2mcpp/blob/main/dslings/cpp14/05-binary-literals-0.cpp) |  |
+
+
+**为什么引入?**
+
+位掩码和标志位用十进制或十六进制表示时, 无法直接对应二进制位布局。`0b0010'1100` 让每一位的含义肉眼可见
+
+## 一、基础用法和场景
+
+```cpp
+int a = 0b1010;       // 10
+int b = 0B1111;       // 15
+
+// 位掩码 — 二进制表示最直观
+constexpr unsigned READ  = 0b001;
+constexpr unsigned WRITE = 0b010;
+constexpr unsigned EXEC  = 0b100;
+
+unsigned perm = 0b101;  // READ | EXEC
+```
+
+## 二、真实案例 - STL 中的二进制字面量
+
+> MSVC STL 在 Unicode 处理中使用二进制字面量表示位掩码, 配合数字分隔符更加清晰。下面以仓库内置的 [MSVC STL](https://github.com/mcpp-community/d2mcpp/tree/main/msvc-stl) 为例 (源码: [`msvc-stl/stl/inc/format`](https://github.com/mcpp-community/d2mcpp/blob/main/msvc-stl/stl/inc/format#L259-L267))
+
+```cpp
+// MSVC STL · msvc-stl/stl/inc/format (有删节)
+// UTF-8 编码 — 按字节数截取有效位
+switch (_Num_bytes) {
+case 2:
+    _Val &= 0b1'1111u;   // 2 字节: 取低 5 位
+    break;
+case 3:
+    _Val &= 0b1111u;     // 3 字节: 取低 4 位
+    break;
+case 4:
+    _Val &= 0b111u;      // 4 字节: 取低 3 位
+}
+```
+
+UTF-8 编码中不同长度字符的有效数据位数不同 (5/4/3 位), 二进制字面量让每一位掩码都对应文档规范中的位布局, 十进制 `31` / `15` / `7` 则完全丢失这层语义
+
+## 三、注意事项
+
+- 二进制字面量只能用于整数类型
+- 可以和数字分隔符组合: `0b1010'1100`
+- 前缀大小写均可, 推荐 `0b` (更常见)
+
+## 四、练习代码
+
+### 练习代码主题
+
+- 0 - [二进制字面量 — 位掩码运算](https://github.com/mcpp-community/d2mcpp/blob/main/dslings/cpp14/05-binary-literals-0.cpp)
+
+### 练习代码自动检测命令
+
+```
+d2x checker binary-literals
+```
+
+## 五、其他
+
+- [交流讨论](https://forum.d2learn.org/category/20)
+- [d2mcpp教程仓库](https://github.com/mcpp-community/d2mcpp)
+- [教程视频列表](https://space.bilibili.com/65858958/lists/5208246)
+- [教程支持工具-xlings](https://github.com/openxlings/xlings)

--- a/dslings/cpp14/05-binary-literals-0.cpp
+++ b/dslings/cpp14/05-binary-literals-0.cpp
@@ -1,0 +1,47 @@
+// d2mcpp: https://github.com/mcpp-community/d2mcpp
+// license: Apache-2.0
+// file: dslings/cpp14/05-binary-literals-0.cpp
+//
+// Exercise/练习: cpp14 | 05 - binary literals | 二进制字面量位掩码
+//
+// Tips/提示:
+// - 0b / 0B 前缀表示二进制字面量
+// - 位掩码用二进制表示最直观
+//
+// Docs/文档:
+//   - https://en.cppreference.com/w/cpp/language/integer_literal
+//   - https://github.com/mcpp-community/d2mcpp/blob/main/book/src/cpp14/05-binary-literals.md
+//
+// 练习交流讨论: http://forum.d2learn.org/category/20
+//
+// Auto-Checker/自动检测命令:
+//
+//   d2x checker binary-literals
+//
+
+#include <d2x/cpp/common.hpp>
+
+constexpr unsigned READ  = 0b001;
+constexpr unsigned WRITE = D2X_YOUR_ANSWER;
+constexpr unsigned EXEC  = 0b100;
+
+bool has_perm(unsigned perm, unsigned flag) { return perm & flag; }
+
+int main() {
+
+    unsigned p1 = 0b101;
+    d2x_assert(has_perm(p1, READ));
+    d2x_assert(!has_perm(p1, WRITE));
+    d2x_assert(has_perm(p1, EXEC));
+
+    unsigned p2 = D2X_YOUR_ANSWER;
+    d2x_assert(has_perm(p2, READ));
+    d2x_assert(has_perm(p2, WRITE));
+    d2x_assert(has_perm(p2, EXEC));
+
+    d2x_assert_eq(0b1111, D2X_YOUR_ANSWER);
+
+    D2X_WAIT
+
+    return 0;
+}

--- a/dslings/cpp14/xmake.lua
+++ b/dslings/cpp14/xmake.lua
@@ -9,3 +9,9 @@ target("cpp14-00-generic-lambdas-0")
 target("cpp14-00-generic-lambdas-1")
     set_kind("binary")
     add_files("00-generic-lambdas-1.cpp")
+
+-- target: cpp14-05-binary-literals
+
+target("cpp14-05-binary-literals-0")
+    set_kind("binary")
+    add_files("05-binary-literals-0.cpp")

--- a/dslings/en/cpp14/05-binary-literals-0.cpp
+++ b/dslings/en/cpp14/05-binary-literals-0.cpp
@@ -1,0 +1,47 @@
+// d2mcpp: https://github.com/mcpp-community/d2mcpp
+// license: Apache-2.0
+// file: dslings/en/cpp14/05-binary-literals-0.cpp
+//
+// Exercise: cpp14 | 05 - binary literals | bit mask operations
+//
+// Tips:
+// - 0b / 0B prefix for binary integer literals
+// - Bit masks are most intuitive in binary form
+//
+// Docs:
+//   - https://en.cppreference.com/w/cpp/language/integer_literal
+//   - https://github.com/mcpp-community/d2mcpp/blob/main/book/en/src/cpp14/05-binary-literals.md
+//
+// Discussion Forum: http://forum.d2learn.org/category/20
+//
+// Auto-Checker:
+//
+//   d2x checker binary-literals
+//
+
+#include <d2x/cpp/common.hpp>
+
+constexpr unsigned READ  = 0b001;
+constexpr unsigned WRITE = D2X_YOUR_ANSWER;
+constexpr unsigned EXEC  = 0b100;
+
+bool has_perm(unsigned perm, unsigned flag) { return perm & flag; }
+
+int main() {
+
+    unsigned p1 = 0b101;
+    d2x_assert(has_perm(p1, READ));
+    d2x_assert(!has_perm(p1, WRITE));
+    d2x_assert(has_perm(p1, EXEC));
+
+    unsigned p2 = D2X_YOUR_ANSWER;
+    d2x_assert(has_perm(p2, READ));
+    d2x_assert(has_perm(p2, WRITE));
+    d2x_assert(has_perm(p2, EXEC));
+
+    d2x_assert_eq(0b1111, D2X_YOUR_ANSWER);
+
+    D2X_WAIT
+
+    return 0;
+}

--- a/dslings/en/cpp14/xmake.lua
+++ b/dslings/en/cpp14/xmake.lua
@@ -9,3 +9,9 @@ target("cpp14-00-generic-lambdas-0")
 target("cpp14-00-generic-lambdas-1")
     set_kind("binary")
     add_files("00-generic-lambdas-1.cpp")
+
+-- target: cpp14-05-binary-literals
+
+target("cpp14-05-binary-literals-0")
+    set_kind("binary")
+    add_files("05-binary-literals-0.cpp")

--- a/solutions/cpp14/05-binary-literals-0.cpp
+++ b/solutions/cpp14/05-binary-literals-0.cpp
@@ -1,0 +1,32 @@
+// d2mcpp: https://github.com/mcpp-community/d2mcpp
+// license: Apache-2.0
+// reference solution for: dslings/cpp14/05-binary-literals-0.cpp
+//
+// 用途: 仅给 CI 与维护者参考使用，不是教程入口。
+// 教程练习入口: dslings/cpp14/05-binary-literals-0.cpp
+//
+
+#include <d2x/cpp/common.hpp>
+
+constexpr unsigned READ  = 0b001;
+constexpr unsigned WRITE = 0b010;
+constexpr unsigned EXEC  = 0b100;
+
+bool has_perm(unsigned perm, unsigned flag) { return perm & flag; }
+
+int main() {
+
+    unsigned p1 = 0b101;
+    d2x_assert(has_perm(p1, READ));
+    d2x_assert(!has_perm(p1, WRITE));
+    d2x_assert(has_perm(p1, EXEC));
+
+    unsigned p2 = 0b111;
+    d2x_assert(has_perm(p2, READ));
+    d2x_assert(has_perm(p2, WRITE));
+    d2x_assert(has_perm(p2, EXEC));
+
+    d2x_assert_eq(0b1111, 15);
+
+    return 0;
+}

--- a/solutions/cpp14/xmake.lua
+++ b/solutions/cpp14/xmake.lua
@@ -9,3 +9,9 @@ target("cpp14-00-generic-lambdas-0-ref")
 target("cpp14-00-generic-lambdas-1-ref")
     set_kind("binary")
     add_files("00-generic-lambdas-1.cpp")
+
+-- target: cpp14-05-binary-literals
+
+target("cpp14-05-binary-literals-0-ref")
+    set_kind("binary")
+    add_files("05-binary-literals-0.cpp")


### PR DESCRIPTION
feat(cpp14): add 05-binary-literals book chapter, exercise, solution, and build wiring

Add the sixth C++14 chapter covering binary literals.

Book chapter (zh + en):
  - section 一/I: Basic usage — binary flags and bit masks
  - section 二/II: Real-world case — UTF-8 encoding bit masks from
    vendored msvc-stl/stl/inc/format#L259-L267, where binary literals
    make the effective-bit-count masks self-documenting
  - section 三/III: Notes
  - section 四/IV: Exercise topics and d2x checker command
  - section 五/V: External resources

Exercise:
  0. Bit mask operations — READ/WRITE/EXEC permission flags.
     3 D2X_YOUR_ANSWER.

Build wiring:
  - register 05 target in dslings/cpp14, dslings/en/cpp14,
    solutions/cpp14
  - add 05 entry to zh/en SUMMARY.md

Closes #67

CLA: I have read the CLA and by submitting this PR agree to its terms.
