### PR TITLE
feat(cpp14): add 06-digit-separators book chapter, exercise, solution, and build wiring

### DIFF
--- a/book/en/src/SUMMARY.md
+++ b/book/en/src/SUMMARY.md
@@ -31,6 +31,7 @@
 # C++14 Core Language Features
 
 - [Generic Lambdas](./cpp14/00-generic-lambdas.md)
+- [Digit Separators](./cpp14/06-digit-separators.md)
 
 # Additional Resources
 

--- a/book/en/src/cpp14/06-digit-separators.md
+++ b/book/en/src/cpp14/06-digit-separators.md
@@ -1,0 +1,67 @@
+<div align=right>
+
+  🌎 [中文] | [English]
+</div>
+
+[中文]: ../../cpp14/06-digit-separators.html
+[English]: ./06-digit-separators.html
+
+# Digit Separators
+
+C++14 allows single quotes `'` as separators in numeric literals, improving readability without affecting the value
+
+| Book | Video | Code | X |
+| --- | --- | --- | --- |
+| [cppreference-integer_literal](https://en.cppreference.com/w/cpp/language/integer_literal) / [markdown](https://github.com/mcpp-community/d2mcpp/blob/main/book/en/src/cpp14/06-digit-separators.md) | [Video Explanation]() | [Exercise Code](https://github.com/mcpp-community/d2mcpp/blob/main/dslings/en/cpp14/06-digit-separators-0.cpp) |  |
+
+
+**Why introduced?**
+
+`1000000000` is hard to parse, `0xFFFF0000` requires counting Fs. `1'000'000'000` and `0xFFFF'0000` make the numeric structure clear at a glance
+
+## I. Basic Usage and Scenarios
+
+```cpp
+int million  = 1'000'000;          // decimal
+int hex_val  = 0xFF'FF'00'00;       // hexadecimal
+int bin_val  = 0b1010'1100'1111;    // binary + separator
+
+static_assert(million == 1000000, "");
+```
+
+## II. Real-World Case — Digit Separators in the STL
+
+> The MSVC STL uses binary literals with digit separators in UTF-8 decoding. The example below cites the vendored [MSVC STL](https://github.com/mcpp-community/d2mcpp/tree/main/msvc-stl) (source: [`msvc-stl/stl/inc/format`](https://github.com/mcpp-community/d2mcpp/blob/main/msvc-stl/stl/inc/format#L281-L282))
+
+```cpp
+// MSVC STL · msvc-stl/stl/inc/format (abridged)
+// UTF-8 decoding — extract the lower 6 bits of each continuation byte
+_Val = (_Val << 6) | (static_cast<unsigned char>(_First[_Idx]) & 0b11'1111u);
+```
+
+`0b11'1111u` is 63, and the `'` separator makes the binary mask's semantics directly visible in the literal — no mental conversion from `0x3F` or `63`
+
+## III. Notes
+
+- Cannot appear at the start or end: `'0` / `1'` are invalid
+- Cannot be consecutive: `1''0` is invalid
+- Does not affect the value, only improves readability
+
+## IV. Exercise Code
+
+### Exercise Topics
+
+- 0 - [Digit Separators — Large Numbers and Radix Combinations](https://github.com/mcpp-community/d2mcpp/blob/main/dslings/en/cpp14/06-digit-separators-0.cpp)
+
+### Auto-Checker Command
+
+```
+d2x checker digit-separators
+```
+
+## V. Other
+
+- [Discussion Forum](https://forum.d2learn.org/category/20)
+- [d2mcpp Tutorial Repository](https://github.com/mcpp-community/d2mcpp)
+- [Tutorial Video List](https://space.bilibili.com/65858958/lists/5208246)
+- [Tutorial Support Tool - xlings](https://github.com/openxlings/xlings)

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -31,6 +31,7 @@
 # C++14核心语言特性
 
 - [泛型 lambda - generic lambdas](./cpp14/00-generic-lambdas.md)
+- [数字分隔符 - digit separators](./cpp14/06-digit-separators.md)
 
 # 其他
 

--- a/book/src/cpp14/06-digit-separators.md
+++ b/book/src/cpp14/06-digit-separators.md
@@ -1,0 +1,69 @@
+<div align=right>
+
+  🌎 [中文] | [English]
+</div>
+
+[中文]: ./06-digit-separators.html
+[English]: ../en/cpp14/06-digit-separators.html
+
+# 数字分隔符 - digit separators
+
+C++14 允许在数字字面量中使用单引号 `'` 作为分隔符, 不影响数值, 显著提升大数可读性
+
+| Book | Video | Code | X |
+| --- | --- | --- | --- |
+| [cppreference-integer_literal](https://en.cppreference.com/w/cpp/language/integer_literal) / [markdown](https://github.com/mcpp-community/d2mcpp/blob/main/book/src/cpp14/06-digit-separators.md) | [视频解读]() | [练习代码](https://github.com/mcpp-community/d2mcpp/blob/main/dslings/cpp14/06-digit-separators-0.cpp) |  |
+
+
+**为什么引入?**
+
+`1000000000` 很难分清位数, `0xFFFF0000` 需要仔细数几位 F。`1'000'000'000` 和 `0xFFFF'0000` 让数值结构一目了然
+
+## 一、基础用法和场景
+
+```cpp
+int million  = 1'000'000;          // 十进制
+int hex_val  = 0xFF'FF'00'00;       // 十六进制
+int bin_val  = 0b1010'1100'1111;    // 二进制 + 分隔符
+
+static_assert(million == 1000000, "");
+```
+
+分隔符可以出现在数字中任意位置, 不限制分组位数
+
+## 二、真实案例 - STL 中的数字分隔符
+
+> MSVC STL 在 UTF-8 解码中使用二进制字面量配合数字分隔符。下面以仓库内置的 [MSVC STL](https://github.com/mcpp-community/d2mcpp/tree/main/msvc-stl) 为例 (源码: [`msvc-stl/stl/inc/format`](https://github.com/mcpp-community/d2mcpp/blob/main/msvc-stl/stl/inc/format#L281-L282))
+
+```cpp
+// MSVC STL · msvc-stl/stl/inc/format (有删节)
+// UTF-8 解码 — 提取连续字节的低 6 位
+_Val = (_Val << 6) | (static_cast<unsigned char>(_First[_Idx]) & 0b11'1111u);
+```
+
+`0b11'1111u` 是 63, 用 `'` 将高位和低位分开后, 二进制掩码的语义直接从字面量可见, 无需心算 `0x3F` 或 `63`
+
+## 三、注意事项
+
+- 不能出现在数字开头或结尾: `'0` / `1'` 非法
+- 不能连续: `1''0` 非法
+- 不影响数值, 仅增强可读性
+
+## 四、练习代码
+
+### 练习代码主题
+
+- 0 - [数字分隔符 — 大数与进制组合](https://github.com/mcpp-community/d2mcpp/blob/main/dslings/cpp14/06-digit-separators-0.cpp)
+
+### 练习代码自动检测命令
+
+```
+d2x checker digit-separators
+```
+
+## 五、其他
+
+- [交流讨论](https://forum.d2learn.org/category/20)
+- [d2mcpp教程仓库](https://github.com/mcpp-community/d2mcpp)
+- [教程视频列表](https://space.bilibili.com/65858958/lists/5208246)
+- [教程支持工具-xlings](https://github.com/openxlings/xlings)

--- a/dslings/cpp14/06-digit-separators-0.cpp
+++ b/dslings/cpp14/06-digit-separators-0.cpp
@@ -1,0 +1,38 @@
+// d2mcpp: https://github.com/mcpp-community/d2mcpp
+// license: Apache-2.0
+// file: dslings/cpp14/06-digit-separators-0.cpp
+//
+// Exercise/练习: cpp14 | 06 - digit separators | 数字分隔符
+//
+// Tips/提示:
+// - 单引号 ' 分隔数字, 不影响数值
+// - 可用于十进制、十六进制、二进制字面量
+//
+// Docs/文档:
+//   - https://en.cppreference.com/w/cpp/language/integer_literal
+//   - https://github.com/mcpp-community/d2mcpp/blob/main/book/src/cpp14/06-digit-separators.md
+//
+// 练习交流讨论: http://forum.d2learn.org/category/20
+//
+// Auto-Checker/自动检测命令:
+//
+//   d2x checker digit-separators
+//
+
+#include <d2x/cpp/common.hpp>
+
+int main() {
+
+    int million = 1'D2X_YOUR_ANSWER'000;
+    d2x_assert_eq(million, 1000000);
+
+    int hex_color = 0xFF'D2X_YOUR_ANSWER'BB;
+    d2x_assert_eq(hex_color, 0xFFAABB);
+
+    int bin_val = 0b1010'D2X_YOUR_ANSWER;
+    d2x_assert_eq(bin_val, 0b10101100);
+
+    D2X_WAIT
+
+    return 0;
+}

--- a/dslings/cpp14/xmake.lua
+++ b/dslings/cpp14/xmake.lua
@@ -9,3 +9,9 @@ target("cpp14-00-generic-lambdas-0")
 target("cpp14-00-generic-lambdas-1")
     set_kind("binary")
     add_files("00-generic-lambdas-1.cpp")
+
+-- target: cpp14-06-digit-separators
+
+target("cpp14-06-digit-separators-0")
+    set_kind("binary")
+    add_files("06-digit-separators-0.cpp")

--- a/dslings/en/cpp14/06-digit-separators-0.cpp
+++ b/dslings/en/cpp14/06-digit-separators-0.cpp
@@ -1,0 +1,38 @@
+// d2mcpp: https://github.com/mcpp-community/d2mcpp
+// license: Apache-2.0
+// file: dslings/en/cpp14/06-digit-separators-0.cpp
+//
+// Exercise: cpp14 | 06 - digit separators
+//
+// Tips:
+// - Single quotes ' separate digits without affecting the value
+// - Works with decimal, hex, and binary literals
+//
+// Docs:
+//   - https://en.cppreference.com/w/cpp/language/integer_literal
+//   - https://github.com/mcpp-community/d2mcpp/blob/main/book/en/src/cpp14/06-digit-separators.md
+//
+// Discussion Forum: http://forum.d2learn.org/category/20
+//
+// Auto-Checker:
+//
+//   d2x checker digit-separators
+//
+
+#include <d2x/cpp/common.hpp>
+
+int main() {
+
+    int million = 1'D2X_YOUR_ANSWER'000;
+    d2x_assert_eq(million, 1000000);
+
+    int hex_color = 0xFF'D2X_YOUR_ANSWER'BB;
+    d2x_assert_eq(hex_color, 0xFFAABB);
+
+    int bin_val = 0b1010'D2X_YOUR_ANSWER;
+    d2x_assert_eq(bin_val, 0b10101100);
+
+    D2X_WAIT
+
+    return 0;
+}

--- a/dslings/en/cpp14/xmake.lua
+++ b/dslings/en/cpp14/xmake.lua
@@ -9,3 +9,9 @@ target("cpp14-00-generic-lambdas-0")
 target("cpp14-00-generic-lambdas-1")
     set_kind("binary")
     add_files("00-generic-lambdas-1.cpp")
+
+-- target: cpp14-06-digit-separators
+
+target("cpp14-06-digit-separators-0")
+    set_kind("binary")
+    add_files("06-digit-separators-0.cpp")

--- a/solutions/cpp14/06-digit-separators-0.cpp
+++ b/solutions/cpp14/06-digit-separators-0.cpp
@@ -1,0 +1,23 @@
+// d2mcpp: https://github.com/mcpp-community/d2mcpp
+// license: Apache-2.0
+// reference solution for: dslings/cpp14/06-digit-separators-0.cpp
+//
+// 用途: 仅给 CI 与维护者参考使用，不是教程入口。
+// 教程练习入口: dslings/cpp14/06-digit-separators-0.cpp
+//
+
+#include <d2x/cpp/common.hpp>
+
+int main() {
+
+    int million = 1'000'000;
+    d2x_assert_eq(million, 1000000);
+
+    int hex_color = 0xFF'AA'BB;
+    d2x_assert_eq(hex_color, 0xFFAABB);
+
+    int bin_val = 0b1010'1100;
+    d2x_assert_eq(bin_val, 0b10101100);
+
+    return 0;
+}

--- a/solutions/cpp14/xmake.lua
+++ b/solutions/cpp14/xmake.lua
@@ -9,3 +9,9 @@ target("cpp14-00-generic-lambdas-0-ref")
 target("cpp14-00-generic-lambdas-1-ref")
     set_kind("binary")
     add_files("00-generic-lambdas-1.cpp")
+
+-- target: cpp14-06-digit-separators
+
+target("cpp14-06-digit-separators-0-ref")
+    set_kind("binary")
+    add_files("06-digit-separators-0.cpp")


### PR DESCRIPTION
feat(cpp14): add 06-digit-separators book chapter, exercise, solution, and build wiring

Add the seventh C++14 chapter covering digit separators.

Book chapter (zh + en):
  - section 一/I: Basic usage — decimal, hex, binary with separators
  - section 二/II: Real-world case — UTF-8 continuation byte mask
    0b11'1111u from vendored msvc-stl/stl/inc/format#L281-L282
  - section 三/III: Notes
  - section 四/IV: Exercise topics and d2x checker command
  - section 五/V: External resources

Exercise:
  0. Digit separators in decimal (1'000'000), hex (0xFF'AA'BB),
     and binary (0b1010'1100). 3 D2X_YOUR_ANSWER.

Build wiring:
  - register 06 target in dslings/cpp14, dslings/en/cpp14,
    solutions/cpp14
  - add 06 entry to zh/en SUMMARY.md

Closes #68

CLA: I have read the CLA and by submitting this PR agree to its terms.