### PR TITLE
feat(cpp14): add 07-deprecated-attribute book chapter, exercise, solution, and build wiring

### DIFF
--- a/book/en/src/SUMMARY.md
+++ b/book/en/src/SUMMARY.md
@@ -31,6 +31,7 @@
 # C++14 Core Language Features
 
 - [Generic Lambdas](./cpp14/00-generic-lambdas.md)
+- [deprecated Attribute](./cpp14/07-deprecated-attribute.md)
 
 # Additional Resources
 

--- a/book/en/src/cpp14/07-deprecated-attribute.md
+++ b/book/en/src/cpp14/07-deprecated-attribute.md
@@ -1,0 +1,73 @@
+<div align=right>
+
+  🌎 [中文] | [English]
+</div>
+
+[中文]: ../../cpp14/07-deprecated-attribute.html
+[English]: ./07-deprecated-attribute.html
+
+# deprecated Attribute
+
+C++14 introduces the `[[deprecated]]` attribute to mark deprecated functions, classes, or variables, producing compile-time warnings
+
+| Book | Video | Code | X |
+| --- | --- | --- | --- |
+| [cppreference-attribute](https://en.cppreference.com/w/cpp/language/attributes) / [markdown](https://github.com/mcpp-community/d2mcpp/blob/main/book/en/src/cpp14/07-deprecated-attribute.md) | [Video Explanation]() | [Exercise Code](https://github.com/mcpp-community/d2mcpp/blob/main/dslings/en/cpp14/07-deprecated-attribute-0.cpp) |  |
+
+
+**Why introduced?**
+
+- Before C++11, there was no standard way to mark deprecated APIs — only documentation or non-standard `#warning`
+- `[[deprecated]]` produces warnings at compile time that callers cannot ignore
+
+## I. Basic Usage and Scenarios
+
+```cpp
+[[deprecated("Use new_api() instead")]]
+void old_api() { }
+
+[[deprecated]]
+int legacy_value = 42;
+
+void modern_code() {
+    old_api();       // warning: old_api is deprecated
+    int x = legacy_value;  // warning: legacy_value is deprecated
+}
+```
+
+## II. Real-World Case — [[deprecated]] in the STL
+
+> The MSVC STL wraps `[[deprecated]]` in macros for deprecation warnings on obsolete headers. The example below cites the vendored [MSVC STL](https://github.com/mcpp-community/d2mcpp/tree/main/msvc-stl) (source: [`msvc-stl/stl/inc/yvals_core.h`](https://github.com/mcpp-community/d2mcpp/blob/main/msvc-stl/stl/inc/yvals_core.h#L1057-L1061))
+
+```cpp
+// MSVC STL · msvc-stl/stl/inc/yvals_core.h (abridged)
+#define _CXX17_DEPRECATE_C_HEADER \
+    [[deprecated("warning STL4004: " \
+                 "<ccomplex>, <cstdalign>, <cstdbool>, and <ctgmath> " \
+                 "are deprecated in C++17.")]]
+```
+
+## III. Notes
+
+- Can mark: functions, classes, variables, enums, using aliases
+- Message string is optional but recommended
+- Deprecated does not mean removed — the compiler still generates code
+
+## IV. Exercise Code
+
+### Exercise Topics
+
+- 0 - [[[deprecated]] Attribute — Marking Deprecated Functions](https://github.com/mcpp-community/d2mcpp/blob/main/dslings/en/cpp14/07-deprecated-attribute-0.cpp)
+
+### Auto-Checker Command
+
+```
+d2x checker deprecated-attribute
+```
+
+## V. Other
+
+- [Discussion Forum](https://forum.d2learn.org/category/20)
+- [d2mcpp Tutorial Repository](https://github.com/mcpp-community/d2mcpp)
+- [Tutorial Video List](https://space.bilibili.com/65858958/lists/5208246)
+- [Tutorial Support Tool - xlings](https://github.com/openxlings/xlings)

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -31,6 +31,7 @@
 # C++14核心语言特性
 
 - [泛型 lambda - generic lambdas](./cpp14/00-generic-lambdas.md)
+- [deprecated 属性 - deprecated attribute](./cpp14/07-deprecated-attribute.md)
 
 # 其他
 

--- a/book/src/cpp14/07-deprecated-attribute.md
+++ b/book/src/cpp14/07-deprecated-attribute.md
@@ -1,0 +1,75 @@
+<div align=right>
+
+  🌎 [中文] | [English]
+</div>
+
+[中文]: ./07-deprecated-attribute.html
+[English]: ../en/cpp14/07-deprecated-attribute.html
+
+# deprecated 属性
+
+C++14 引入 `[[deprecated]]` 属性, 允许标记废弃的函数、类或变量, 编译时产生警告
+
+| Book | Video | Code | X |
+| --- | --- | --- | --- |
+| [cppreference-attribute](https://en.cppreference.com/w/cpp/language/attributes) / [markdown](https://github.com/mcpp-community/d2mcpp/blob/main/book/src/cpp14/07-deprecated-attribute.md) | [视频解读]() | [练习代码](https://github.com/mcpp-community/d2mcpp/blob/main/dslings/cpp14/07-deprecated-attribute-0.cpp) |  |
+
+
+**为什么引入?**
+
+- C++11 之前没有标准方式标记废弃 API, 只能靠文档或 `#warning` 等非标准手段
+- `[[deprecated]]` 在编译期产生警告, 调用方无法忽略, 比注释或文档更有效
+
+## 一、基础用法和场景
+
+```cpp
+[[deprecated("Use new_api() instead")]]
+void old_api() { }
+
+[[deprecated]]
+int legacy_value = 42;
+
+void modern_code() {
+    old_api();       // 编译器警告: old_api is deprecated
+    int x = legacy_value;  // 编译器警告: legacy_value is deprecated
+}
+```
+
+## 二、真实案例 - STL 中的 [[deprecated]]
+
+> MSVC STL 使用 `[[deprecated]]` 包装废弃头文件和 API 的警告宏。下面以仓库内置的 [MSVC STL](https://github.com/mcpp-community/d2mcpp/tree/main/msvc-stl) 为例 (源码: [`msvc-stl/stl/inc/yvals_core.h`](https://github.com/mcpp-community/d2mcpp/blob/main/msvc-stl/stl/inc/yvals_core.h#L1057-L1061))
+
+```cpp
+// MSVC STL · msvc-stl/stl/inc/yvals_core.h (有删节)
+#define _CXX17_DEPRECATE_C_HEADER \
+    [[deprecated("warning STL4004: " \
+                 "<ccomplex>, <cstdalign>, <cstdbool>, and <ctgmath> " \
+                 "are deprecated in C++17.")]]
+```
+
+STL 将 `[[deprecated]]` 封装成宏, 在编译期对使用废弃 C 头文件的代码产生标准警告, 用户可借此提前迁移
+
+## 三、注意事项
+
+- 可标记: 函数、类、变量、枚举、using 别名
+- 消息字符串可选但推荐
+- 废弃不等于删除 — 编译器仍正常生成代码
+
+## 四、练习代码
+
+### 练习代码主题
+
+- 0 - [[[deprecated]] 属性 — 标记废弃函数](https://github.com/mcpp-community/d2mcpp/blob/main/dslings/cpp14/07-deprecated-attribute-0.cpp)
+
+### 练习代码自动检测命令
+
+```
+d2x checker deprecated-attribute
+```
+
+## 五、其他
+
+- [交流讨论](https://forum.d2learn.org/category/20)
+- [d2mcpp教程仓库](https://github.com/mcpp-community/d2mcpp)
+- [教程视频列表](https://space.bilibili.com/65858958/lists/5208246)
+- [教程支持工具-xlings](https://github.com/openxlings/xlings)

--- a/dslings/cpp14/07-deprecated-attribute-0.cpp
+++ b/dslings/cpp14/07-deprecated-attribute-0.cpp
@@ -1,0 +1,37 @@
+// d2mcpp: https://github.com/mcpp-community/d2mcpp
+// license: Apache-2.0
+// file: dslings/cpp14/07-deprecated-attribute-0.cpp
+//
+// Exercise/练习: cpp14 | 07 - deprecated attribute | [[deprecated]]
+//
+// Tips/提示:
+// - [[deprecated("message")]] 标记废弃的函数/变量
+// - 调用时编译器产生警告
+//
+// Docs/文档:
+//   - https://en.cppreference.com/w/cpp/language/attributes
+//   - https://github.com/mcpp-community/d2mcpp/blob/main/book/src/cpp14/07-deprecated-attribute.md
+//
+// 练习交流讨论: http://forum.d2learn.org/category/20
+//
+// Auto-Checker/自动检测命令:
+//
+//   d2x checker deprecated-attribute
+//
+
+#include <d2x/cpp/common.hpp>
+
+[[deprecated("Use new_add")]]
+D2X_YOUR_ANSWER old_add(int a, int b) { return a + b; }
+
+int new_add(int a, int b) { return a + b; }
+
+int main() {
+
+    int r = old_add(10, 20);
+    d2x_assert_eq(r, D2X_YOUR_ANSWER);
+
+    D2X_WAIT
+
+    return 0;
+}

--- a/dslings/cpp14/xmake.lua
+++ b/dslings/cpp14/xmake.lua
@@ -9,3 +9,9 @@ target("cpp14-00-generic-lambdas-0")
 target("cpp14-00-generic-lambdas-1")
     set_kind("binary")
     add_files("00-generic-lambdas-1.cpp")
+
+-- target: cpp14-07-deprecated-attribute
+
+target("cpp14-07-deprecated-attribute-0")
+    set_kind("binary")
+    add_files("07-deprecated-attribute-0.cpp")

--- a/dslings/en/cpp14/07-deprecated-attribute-0.cpp
+++ b/dslings/en/cpp14/07-deprecated-attribute-0.cpp
@@ -1,0 +1,37 @@
+// d2mcpp: https://github.com/mcpp-community/d2mcpp
+// license: Apache-2.0
+// file: dslings/en/cpp14/07-deprecated-attribute-0.cpp
+//
+// Exercise: cpp14 | 07 - deprecated attribute | [[deprecated]]
+//
+// Tips:
+// - [[deprecated("message")]] marks deprecated functions/variables
+// - The compiler produces a warning on use
+//
+// Docs:
+//   - https://en.cppreference.com/w/cpp/language/attributes
+//   - https://github.com/mcpp-community/d2mcpp/blob/main/book/en/src/cpp14/07-deprecated-attribute.md
+//
+// Discussion Forum: http://forum.d2learn.org/category/20
+//
+// Auto-Checker:
+//
+//   d2x checker deprecated-attribute
+//
+
+#include <d2x/cpp/common.hpp>
+
+[[deprecated("Use new_add")]]
+D2X_YOUR_ANSWER old_add(int a, int b) { return a + b; }
+
+int new_add(int a, int b) { return a + b; }
+
+int main() {
+
+    int r = old_add(10, 20);
+    d2x_assert_eq(r, D2X_YOUR_ANSWER);
+
+    D2X_WAIT
+
+    return 0;
+}

--- a/dslings/en/cpp14/xmake.lua
+++ b/dslings/en/cpp14/xmake.lua
@@ -9,3 +9,9 @@ target("cpp14-00-generic-lambdas-0")
 target("cpp14-00-generic-lambdas-1")
     set_kind("binary")
     add_files("00-generic-lambdas-1.cpp")
+
+-- target: cpp14-07-deprecated-attribute
+
+target("cpp14-07-deprecated-attribute-0")
+    set_kind("binary")
+    add_files("07-deprecated-attribute-0.cpp")

--- a/solutions/cpp14/07-deprecated-attribute-0.cpp
+++ b/solutions/cpp14/07-deprecated-attribute-0.cpp
@@ -1,0 +1,22 @@
+// d2mcpp: https://github.com/mcpp-community/d2mcpp
+// license: Apache-2.0
+// reference solution for: dslings/cpp14/07-deprecated-attribute-0.cpp
+//
+// 用途: 仅给 CI 与维护者参考使用，不是教程入口。
+// 教程练习入口: dslings/cpp14/07-deprecated-attribute-0.cpp
+//
+
+#include <d2x/cpp/common.hpp>
+
+[[deprecated("Use new_add")]]
+int old_add(int a, int b) { return a + b; }
+
+int new_add(int a, int b) { return a + b; }
+
+int main() {
+
+    int r = old_add(10, 20);
+    d2x_assert_eq(r, 30);
+
+    return 0;
+}

--- a/solutions/cpp14/xmake.lua
+++ b/solutions/cpp14/xmake.lua
@@ -9,3 +9,9 @@ target("cpp14-00-generic-lambdas-0-ref")
 target("cpp14-00-generic-lambdas-1-ref")
     set_kind("binary")
     add_files("00-generic-lambdas-1.cpp")
+
+-- target: cpp14-07-deprecated-attribute
+
+target("cpp14-07-deprecated-attribute-0-ref")
+    set_kind("binary")
+    add_files("07-deprecated-attribute-0.cpp")


### PR DESCRIPTION
feat(cpp14): add 07-deprecated-attribute book chapter, exercise, solution, and build wiring

Add the eighth C++14 chapter covering the [[deprecated]] attribute.

Book chapter (zh + en):
  - section 一/I: Basic usage — marking functions and variables
  - section 二/II: Real-world case — _CXX17_DEPRECATE_C_HEADER macro
    from vendored msvc-stl/stl/inc/yvals_core.h#L1057-L1061
  - section 三/III: Notes
  - section 四/IV: Exercise topics and d2x checker command
  - section 五/V: External resources

Exercise:
  0. Mark a deprecated function with a message and verify it still
     compiles and works correctly. 2 D2X_YOUR_ANSWER.

Build wiring:
  - register 07 target in dslings/cpp14, dslings/en/cpp14,
    solutions/cpp14
  - add 07 entry to zh/en SUMMARY.md

Closes #69

CLA: I have read the CLA and by submitting this PR agree to its terms.
