### PR TITLE
docs: 修复 README 中的 Star History 图表链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ d2x status                   # progress overview
 
 **👥Contributors**
 
-[![Star History Chart](https://api.star-history.com/svg?repos=mcpp-community/d2mcpp&type=date&legend=top-left)](https://www.star-history.com/#mcpp-community/d2mcpp&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=mcpp-community/d2mcpp&type=date&legend=top-left)](https://star-history.dera.page/#mcpp-community/d2mcpp&type=date&legend=top-left)
 
 <a href="https://github.com/mcpp-community/d2mcpp/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=mcpp-community/d2mcpp" />

--- a/README.zh.hant.md
+++ b/README.zh.hant.md
@@ -133,7 +133,7 @@ d2x status                   # 進度總覽
 
 **👥貢獻者**
 
-[![Star History Chart](https://api.star-history.com/svg?repos=mcpp-community/d2mcpp&type=date&legend=top-left)](https://www.star-history.com/#mcpp-community/d2mcpp&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=mcpp-community/d2mcpp&type=date&legend=top-left)](https://star-history.dera.page/#mcpp-community/d2mcpp&type=date&legend=top-left)
 
 <a href="https://github.com/mcpp-community/d2mcpp/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=mcpp-community/d2mcpp" />

--- a/README.zh.md
+++ b/README.zh.md
@@ -133,7 +133,7 @@ d2x status                   # 进度总览
 
 **👥贡献者**
 
-[![Star History Chart](https://api.star-history.com/svg?repos=mcpp-community/d2mcpp&type=date&legend=top-left)](https://www.star-history.com/#mcpp-community/d2mcpp&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=mcpp-community/d2mcpp&type=date&legend=top-left)](https://star-history.dera.page/#mcpp-community/d2mcpp&type=date&legend=top-left)
 
 <a href="https://github.com/mcpp-community/d2mcpp/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=mcpp-community/d2mcpp" />


### PR DESCRIPTION
当前 README(含中英文及繁体中文版本)中的 Star History 图表因 GitHub stargazer API 限制而失效,无法正常展示。本次 PR 将图表镜像地址及外层链接切换到可用的新域名,无需 API token,恢复 Star History 图表展示。